### PR TITLE
fix typo in crate init, some small changes to the tests

### DIFF
--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -1189,7 +1189,7 @@ void *ControllerLink::ProcessCommand(void *arg)
     uint32_t slotMask = GetUInt(input,'s',0xFFFF);
     uint32_t channelMask = GetUInt(input,'p',0xFFFFFFFF);
     int dacValue = GetInt(input,'v',255);
-    float frequency = GetFloat(input,'f',0);
+    float frequency = GetFloat(input,'f',10);
     int update = GetFlag(input,'d');
     int busy = LockConnections(1,0x1<<crateNum);
     if (busy){

--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -930,9 +930,9 @@ void *ControllerLink::ProcessCommand(void *arg)
     }
     int crateNum = GetInt(input,'c',2);
     uint32_t slotMask = GetUInt(input,'s',0xFFFF);
-    int upper = GetInt(input,'u',3550);
-    int lower = GetInt(input,'l',3000);
-    int num = GetInt(input,'n',550);
+    int upper = GetInt(input,'u',3500);
+    int lower = GetInt(input,'l',750);
+    int num = GetInt(input,'n',200);
     int samples = GetInt(input,'p',1);
     int update = GetFlag(input,'d');
     int busy = LockConnections(0,0x1<<crateNum);
@@ -1092,7 +1092,7 @@ void *ControllerLink::ProcessCommand(void *arg)
     int crateNum = GetInt(input,'c',2);
     uint32_t slotMask = GetUInt(input,'s',0xFFFF);
     uint32_t channelMask = GetUInt(input,'p',0xFFFFFFFF);
-    float gtCutoff = GetFloat(input,'g',0);
+    float gtCutoff = GetFloat(input,'g',410);
     int twiddleOn = GetFlag(input,'t');
     int update = GetFlag(input,'d');
     int busy = LockConnections(1,0x1<<crateNum);
@@ -1262,7 +1262,7 @@ void *ControllerLink::ProcessCommand(void *arg)
     }
     int crateNum = GetInt(input,'c',2);
     uint32_t slotMask = GetUInt(input,'s',0xFFFF);
-    int targetTime = GetInt(input,'t',400);
+    int targetTime = GetInt(input,'t',420);
     int update = GetFlag(input,'d');
     int busy = LockConnections(1,0x1<<crateNum);
     if (busy){

--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -930,9 +930,9 @@ void *ControllerLink::ProcessCommand(void *arg)
     }
     int crateNum = GetInt(input,'c',2);
     uint32_t slotMask = GetUInt(input,'s',0xFFFF);
-    int upper = GetInt(input,'u',3500);
-    int lower = GetInt(input,'l',750);
-    int num = GetInt(input,'n',200);
+    int upper = GetInt(input,'u',3550);
+    int lower = GetInt(input,'l',3000);
+    int num = GetInt(input,'n',550);
     int samples = GetInt(input,'p',1);
     int update = GetFlag(input,'d');
     int busy = LockConnections(0,0x1<<crateNum);
@@ -1262,7 +1262,7 @@ void *ControllerLink::ProcessCommand(void *arg)
     }
     int crateNum = GetInt(input,'c',2);
     uint32_t slotMask = GetUInt(input,'s',0xFFFF);
-    int targetTime = GetInt(input,'t',420);
+    int targetTime = GetInt(input,'t',400);
     int update = GetFlag(input,'d');
     int busy = LockConnections(1,0x1<<crateNum);
     if (busy){

--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -1159,8 +1159,8 @@ void *ControllerLink::ProcessCommand(void *arg)
     int crateNum = GetInt(input,'c',2);
     uint32_t slotMask = GetUInt(input,'s',0xFFFF);
     uint32_t channelMask = GetUInt(input,'p',0xFFFFFFFF);
-    int lower = GetInt(input,'l',400);
-    int upper = GetInt(input,'u',700);
+    int lower = GetInt(input,'l',300);
+    int upper = GetInt(input,'u',1000);
     float frequency = GetFloat(input,'f',0);
     int numPeds = GetInt(input,'n',50);
     int gtDelay = GetInt(input,'t',DEFAULT_GT_DELAY);

--- a/src/tests/ECAL.cpp
+++ b/src/tests/ECAL.cpp
@@ -36,7 +36,8 @@ int ECAL(uint32_t crateMask, uint32_t *slotMasks, uint32_t testMask, const char*
     lprintf("Problem enabling logging for ecal, could not open log file!\n");
 
 
-  lprintf("*** Starting ECAL **********************\n");
+  lprintf("*** Starting ECAL *****************************\n");
+  lprintf("*** Make sure the ECAL cable is plugged in ****\n");
 
   char comments[1000];
   memset(comments,'\0',1000);
@@ -247,7 +248,8 @@ int ECAL(uint32_t crateMask, uint32_t *slotMasks, uint32_t testMask, const char*
   if (createFECDocs)
     GenerateFECDocFromECAL(0x0, ecalID);
 
-  lprintf("****************************************\n");
+  lprintf("**********************************************\n");
+  lprintf("*** Make sure the ECAL cable is unplugged ****\n");
   fclose(ecalLogFile);
   return 0;
 }

--- a/src/tests/FinalTest.cpp
+++ b/src/tests/FinalTest.cpp
@@ -208,6 +208,9 @@ int FinalTest(int crateNum, uint32_t slotMask, uint32_t testMask, int skip)
   if ((0x1<<testCounter) & testMask)
     GTValidTest(crateNum,slotMask,0xFFFFFFFF,400,0,updateDB,1);
   testCounter++;
+
+  CrateInit(crateNum,slotMask,1,0,0,0,0,0,0,0);
+  
   if ((0x1<<testCounter) & testMask)
     ZDisc(crateNum,slotMask,10000,0,updateDB,1);
   testCounter++;

--- a/src/xl3/XL3Cmds.cpp
+++ b/src/xl3/XL3Cmds.cpp
@@ -76,7 +76,7 @@ int CrateInit(int crateNum,uint32_t slotMask, int xilinxLoad,
   if (xilinxLoad) {
     lprintf("sending crate reset to load xilinx\n");
 
-    memset(&packet, 0 sizeof(XL3Packet));
+    memset(&packet, 0, sizeof(XL3Packet));
 
     packet.header.packetNum = htons(0);
     packet.header.packetType = RESET_CRATE_ID;
@@ -97,7 +97,7 @@ int CrateInit(int crateNum,uint32_t slotMask, int xilinxLoad,
 
   lprintf("Now sending database to XL3\n");
 
-  memset(&packet, 0 sizeof(XL3Packet));
+  memset(&packet, 0, sizeof(XL3Packet));
 
   try{
 


### PR DESCRIPTION
- fix typo in crate init
- change vmon test so bad voltages are easy to see
- Add a crate init in final test so zdisc doesn't fail
- change the charge limits in which ped_run fails when run outside of an ECAL to the same limits it fails from within an ECAL
- Set default see_refl frequency from 0 to 10Hz
- Set default gtvalid window to 410
- Remind about the ECAL cable before starting and after it finishes