### PR TITLE
add error to chinj scan for missing pmt signal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CDIRS = $(patsubst %,$(CDIR)/%,$(_CDIRS))
 vpath %.h $(CDIRS)
 vpath %.cpp $(CDIRS)
 
-_OBJ = Main.o NetUtils.o XL3Link.o GenericLink.o ControllerLink.o XL3Cmds.o Globals.o XL3Model.o DB.o Json.o Pouch.o MTCLink.o MTCCmds.o MTCModel.o FECTest.o MemTest.o BoardID.o CaldTest.o CGTTest.o ChinjScan.o CrateCBal.o DiscCheck.o FifoTest.o GTValidTest.o MbStabilityTest.o PedRun.o SeeReflection.o TriggerScan.o TTot.o VMon.o ZDisc.o RunPedestals.o FinalTest.o ECAL.o FindNoise.o DACSweep.o LocalVMon.o
+_OBJ = Main.o NetUtils.o XL3Link.o GenericLink.o ControllerLink.o XL3Cmds.o Globals.o XL3Model.o DB.o Json.o Pouch.o MTCLink.o MTCCmds.o MTCModel.o FECTest.o MemTest.o BoardID.o CaldTest.o CGTTest.o ChinjScan.o CrateCBal.o DiscCheck.o FifoTest.o GTValidTest.o MbStabilityTest.o PedRun.o SeeReflection.o SeeReflectionEsum.o TriggerScan.o TTot.o VMon.o ZDisc.o RunPedestals.o FinalTest.o ECAL.o FindNoise.o DACSweep.o LocalVMon.o
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
 
 _DEPS = $(_OBJ:.o=.h) DBTypes.h XL3PacketTypes.h MTCPacketTypes.h  XL3Registers.h UnpackBundles.h DacNumber.h MTCRegisters.h

--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -987,7 +987,7 @@ void *ControllerLink::ProcessCommand(void *arg)
     int numPeds = GetInt(input,'n',10);
     float lower = GetFloat(input,'l',200);
     float upper = GetFloat(input,'u',3000);
-    float pmt = GetFloat(input, 'q', 1000);
+    float pmt = GetFloat(input, 'q', 200);
     int pedOn = GetInt(input,'e',1);
     int update = GetFlag(input,'d');
     int busy = LockConnections(1,0x1<<crateNum);

--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -20,6 +20,7 @@
 #include "MemTest.h"
 #include "PedRun.h"
 #include "SeeReflection.h"
+#include "SeeReflectionEsum.h"
 #include "TriggerScan.h"
 #include "TTot.h"
 #include "VMon.h"
@@ -1200,6 +1201,31 @@ void *ControllerLink::ProcessCommand(void *arg)
       goto err;
     }
     SeeReflection(crateNum,slotMask,channelMask,dacValue,frequency,update);
+    UnlockConnections(1,0x1<<crateNum);
+
+  }else if (strncmp(input,"esum_see_refl",13) == 0){
+    if (GetFlag(input,'h')){
+      lprintf("Usage: esum_see_refl -c [crate num (int)] "
+          "-v [dac value (int)] -s [slot mask (hex)] "
+          "-f [frequency (float)] "
+          "-d (update database)\n");
+      goto err;
+    }
+    int crateNum = GetInt(input,'c',2);
+    uint32_t slotMask = GetUInt(input,'s',0xFFFF);
+    uint32_t channelMask = GetUInt(input,'p',0xFFFFFFFF);
+    int dacValue = GetInt(input,'v',255);
+    float frequency = GetFloat(input,'f',10);
+    int update = GetFlag(input,'d');
+    int busy = LockConnections(1,0x1<<crateNum);
+    if (busy){
+      if (busy > 9)
+        lprintf("Trying to access a board that has not been connected\n");
+      else
+        lprintf("ThoseConnections are currently in use.\n");
+      goto err;
+    }
+    SeeReflectionEsum(crateNum,slotMask,dacValue,frequency,update);
     UnlockConnections(1,0x1<<crateNum);
 
   }else if (strncmp(input,"trigger_scan",12) == 0){

--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -973,7 +973,7 @@ void *ControllerLink::ProcessCommand(void *arg)
           "-s [slot mask (hex)] -p [channel mask (hex)] "
           "-f [frequency] -t [gtdelay] -w [ped with] -n [num pedestals] "
           "-l [charge lower limit] -u [charge upper limit] "
-          "-a [charge select (0=qhl,1=qhs,2=qlx,3=tac)] "
+          "-q [lower limit on QHL for max DAC chinj] "
           "-e [enable pedestals (0=off, 1=on)] -d (update database)\n");
       goto err;
     }
@@ -984,9 +984,9 @@ void *ControllerLink::ProcessCommand(void *arg)
     int gtDelay = GetInt(input,'t',DEFAULT_GT_DELAY);
     int pedWidth = GetInt(input,'w',DEFAULT_PED_WIDTH);
     int numPeds = GetInt(input,'n',10);
-    float lower = GetFloat(input,'l',400);
-    float upper = GetFloat(input,'u',5000);
-    int qSelect = GetInt(input,'a',0);
+    float lower = GetFloat(input,'l',200);
+    float upper = GetFloat(input,'u',3000);
+    float pmt = GetFloat(input, 'q', 1000);
     int pedOn = GetInt(input,'e',1);
     int update = GetFlag(input,'d');
     int busy = LockConnections(1,0x1<<crateNum);
@@ -997,7 +997,7 @@ void *ControllerLink::ProcessCommand(void *arg)
         lprintf("ThoseConnections are currently in use.\n");
       goto err;
     }
-    ChinjScan(crateNum,slotMask,channelMask,freq,gtDelay,pedWidth,numPeds,upper,lower,qSelect,pedOn,update);
+    ChinjScan(crateNum,slotMask,channelMask,freq,gtDelay,pedWidth,numPeds,upper,lower,pmt,pedOn,update);
     UnlockConnections(1,0x1<<crateNum);
 
   }else if (strncmp(input,"crate_cbal",10) == 0){

--- a/src/tests/ChinjScan.cpp
+++ b/src/tests/ChinjScan.cpp
@@ -29,6 +29,7 @@ int ChinjScan(int crateNum, uint32_t slotMask, uint32_t channelMask, float frequ
   uint32_t result, select_reg;
   uint32_t default_ch_mask;
   int chinj_err[16];
+  float pedestal_charge[32]={0};
 
   pmt_buffer = (uint32_t *) malloc( 0x20000*sizeof(uint32_t));
   ped = (struct pedestal *) malloc( 32 * sizeof(struct pedestal));
@@ -304,16 +305,20 @@ int ChinjScan(int crateNum, uint32_t slotMask, uint32_t channelMask, float frequ
                     ped[i].thiscell[j].qhsbar, ped[i].thiscell[j].qhsrms,
                     ped[i].thiscell[j].qlxbar, ped[i].thiscell[j].qlxrms,
                     ped[i].thiscell[j].tacbar, ped[i].thiscell[j].tacrms);
-              }
-              if (j==0){ // Only the first cell
+                if (dacvalue == 0){
+                  pedestal_charge[i] = ped[i].thiscell[j].qhlbar;
+                } 
                 if (dacvalue == 250){ // Only the large DAC value
-                  if(ped[i].thiscell[j].qhlbar < pmt){ // Checks whether integrator is geting pmt input
+                  // Checks whether integrator is getting pmt input
+                  float charge_difference = ped[i].thiscell[j].qhlbar - pedestal_charge[i];
+                  if(charge_difference < pmt){
                      chinj_err[slot_iter]++;
                      scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2+1]++;
+                     lprintf("Difference between pedestal and max chinj is %4.1f\n",charge_difference); 
                      lprintf("Probably missing pmt input channel %d\n", i);
                   }
                 }
-              }               
+              }
             }
           }
 

--- a/src/tests/ChinjScan.cpp
+++ b/src/tests/ChinjScan.cpp
@@ -12,7 +12,7 @@
 #include "MTCModel.h"
 #include "ChinjScan.h"
 
-int ChinjScan(int crateNum, uint32_t slotMask, uint32_t channelMask, float frequency, int gtDelay, int pedWidth, int numPedestals, float upper, float lower, int qSelect, int pedOn, int updateDB, int finalTest)
+int ChinjScan(int crateNum, uint32_t slotMask, uint32_t channelMask, float frequency, int gtDelay, int pedWidth, int numPedestals, float upper, float lower, float pmt, int pedOn, int updateDB, int finalTest)
 {
   lprintf("*** Starting Charge Injection Test *****\n");
 
@@ -270,38 +270,32 @@ int ChinjScan(int crateNum, uint32_t slotMask, uint32_t channelMask, float frequ
                 qlxs[dac_iter*16*32*2+slot_iter*32*2+i*2+1] = ped[i].thiscell[j].qlxbar;
                 tacs[dac_iter*16*32*2+slot_iter*32*2+i*2+1] = ped[i].thiscell[j].tacbar;
               }
-              if (qSelect == 0){
-                if (ped[i].thiscell[j].qhlbar < lower ||
-                    ped[i].thiscell[j].qhlbar > upper) {
-                  chinj_err[slot_iter]++;
-                  //pt_printsend(">>>>>Qhl Extreme Value<<<<<\n");
-                  if (j%2 == 0)
-                    scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2]++;
-                  else
-                    scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2+1]++;
-                }
+              if (ped[i].thiscell[j].qhlbar < lower ||
+                  ped[i].thiscell[j].qhlbar > upper) {
+                chinj_err[slot_iter]++;
+                //pt_printsend(">>>>>Qhl Extreme Value<<<<<\n");
+                if (j%2 == 0)
+                  scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2]++;
+                else
+                  scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2+1]++;
               }
-              else if (qSelect == 1){
-                if (ped[i].thiscell[j].qhsbar < lower ||
-                    ped[i].thiscell[j].qhsbar > upper) {
-                  chinj_err[slot_iter]++;
-                  //pt_printsend(">>>>>Qhs Extreme Value<<<<<\n");
-                  if (j%2 == 0)
-                    scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2]++;
-                  else
-                    scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2+1]++;
-                }
+              if (ped[i].thiscell[j].qhsbar < lower ||
+                  ped[i].thiscell[j].qhsbar > upper) {
+                chinj_err[slot_iter]++;
+                //pt_printsend(">>>>>Qhs Extreme Value<<<<<\n");
+                if (j%2 == 0)
+                  scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2]++;
+                else
+                  scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2+1]++;
               }
-              else if (qSelect == 2){
-                if (ped[i].thiscell[j].qlxbar < lower ||
-                    ped[i].thiscell[j].qlxbar > upper) {
-                  chinj_err[slot_iter]++;
-                  //pt_printsend(">>>>>Qlx Extreme Value<<<<<\n");
-                  if (j%2 == 0)
-                    scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2]++;
-                  else
-                    scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2+1]++;
-                }
+              if (ped[i].thiscell[j].qlxbar < lower ||
+                  ped[i].thiscell[j].qlxbar > upper) {
+                chinj_err[slot_iter]++;
+                //pt_printsend(">>>>>Qlx Extreme Value<<<<<\n");
+                if (j%2 == 0)
+                  scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2]++;
+                else
+                  scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2+1]++;
               }
               if (j==0){
                 lprintf("%2d %3d %4d %6.1f %4.1f %6.1f %4.1f %6.1f %4.1f %6.1f %4.1f\n",
@@ -311,6 +305,15 @@ int ChinjScan(int crateNum, uint32_t slotMask, uint32_t channelMask, float frequ
                     ped[i].thiscell[j].qlxbar, ped[i].thiscell[j].qlxrms,
                     ped[i].thiscell[j].tacbar, ped[i].thiscell[j].tacrms);
               }
+              if (j==0){ // Only the first cell
+                if (dacvalue == 250){ // Only the large DAC value
+                  if(ped[i].thiscell[j].qhlbar < pmt){ // Checks whether integrator is geting pmt input
+                     chinj_err[slot_iter]++;
+                     scan_errors[dac_iter*16*32*2+slot_iter*32*2+i*2+1]++;
+                     lprintf("Probably missing pmt input channel %d\n", i);
+                  }
+                }
+              }               
             }
           }
 

--- a/src/tests/ChinjScan.h
+++ b/src/tests/ChinjScan.h
@@ -3,7 +3,7 @@
 
 #include <unistd.h>
 
-int ChinjScan(int crateNum, uint32_t slotMask, uint32_t channelMask, float frequency, int gtDelay, int pedWidth, int numPedestals, float upper, float lower, int qSelect, int pedOn, int updateDB, int finalTest=0);
+int ChinjScan(int crateNum, uint32_t slotMask, uint32_t channelMask, float frequency, int gtDelay, int pedWidth, int numPedestals, float upper, float lower, float pmt, int pedOn, int updateDB, int finalTest=0);
 
 #endif
 

--- a/src/tests/SeeReflectionEsum.cpp
+++ b/src/tests/SeeReflectionEsum.cpp
@@ -1,0 +1,106 @@
+#include "XL3PacketTypes.h"
+#include "XL3Registers.h"
+#include "UnpackBundles.h"
+#include "Globals.h"
+#include "Json.h"
+
+#include "DB.h"
+#include "ControllerLink.h"
+#include "XL3Model.h"
+#include "MTCModel.h"
+#include "SeeReflectionEsum.h"
+
+int SeeReflectionEsum(int crateNum, uint32_t slotMask, int dacValue, float frequency, int updateDB, int finalTest)
+{
+  lprintf("*** Starting See Reflection ESUM ************\n");
+
+  char channel_results[8][100];
+
+  try {
+
+    // set up pulser
+    int errors = mtc->SetupPedestals(frequency, DEFAULT_PED_WIDTH, DEFAULT_GT_DELAY,0,
+        (0x1<<crateNum),(0x1<<crateNum) | MSK_TUB);
+    if (errors){
+      lprintf("Error setting up MTC for pedestals. Exiting\n");
+      mtc->UnsetPedCrateMask(MASKALL);
+      mtc->UnsetGTCrateMask(MASKALL);
+      return -1;
+    }
+
+    // loop over slots
+    for (int i=0;i<16;i++){
+      if ((0x1<<i) & slotMask){
+        // loop over channels
+        for (int j=0;j<8;j++){
+         int four_channels = j*4;
+         uint32_t temp_pattern = 0xf<<four_channels;
+          memset(channel_results[j],'\0',100);
+
+          // set up charge injection for four channels at a time
+          xl3s[crateNum]->SetupChargeInjection((0x1<<i),temp_pattern,dacValue);
+          // wait until something is typed
+          lprintf("Slot %d, channel %d. If good, hit enter. Otherwise type in a description of the problem (or just \"fail\") and hit enter.\n",i,j);
+
+          contConnection->GetInput(channel_results[j],100);
+
+          for (int k=0;k<strlen(channel_results[j]);k++)
+            if (channel_results[j][k] == '\n')
+              channel_results[j][k] = '\0';
+
+          if (strncmp(channel_results[j],"quit",4) == 0){
+            lprintf("Quitting.\n");
+            mtc->DisablePulser();
+            xl3s[crateNum]->DeselectFECs();
+            return 0;
+          }
+        } // end loop over channels
+
+        // clear chinj for this slot
+        xl3s[crateNum]->SetupChargeInjection((0x1<<i),0x0,dacValue);
+
+        // update the database
+        if (updateDB){
+          lprintf("updating the database\n");
+          lprintf("updating slot %d\n",i);
+          JsonNode *newdoc = json_mkobject();
+          json_append_member(newdoc,"type",json_mkstring("see_refl_esum"));
+
+          int passflag = 1;
+          JsonNode *all_channels = json_mkarray();
+          for (int j=0;j<8;j++){
+            JsonNode *one_chan = json_mkobject();
+            json_append_member(one_chan,"id",json_mknumber(j));
+            if (strlen(channel_results[j]) != 0){
+              passflag = 0;
+              json_append_member(one_chan,"error",json_mkstring(channel_results[j]));
+            }else{
+              json_append_member(one_chan,"error",json_mkstring(""));
+            }
+            json_append_element(all_channels,one_chan);
+          }
+          json_append_member(newdoc,"channels",all_channels);
+          json_append_member(newdoc,"pass",json_mkbool(passflag));
+          if (finalTest)
+            json_append_member(newdoc,"final_test_id",json_mkstring(finalTestIDs[crateNum][i]));	
+          PostDebugDoc(crateNum,i,newdoc);
+          json_delete(newdoc); // Only have to delete the head node
+        }
+      } // end if slot mask
+    } // end loop over slots
+
+    mtc->DisablePulser();
+    xl3s[crateNum]->DeselectFECs();
+
+    if (errors)
+      lprintf("There were %d errors.\n",errors);
+    else
+      lprintf("No errors.\n");
+  }
+  catch(const char* s){
+    lprintf("SeeReflectionEsum: %s\n",s);
+  }
+
+  lprintf("****************************************\n");
+  return 0;
+}

--- a/src/tests/SeeReflectionEsum.h
+++ b/src/tests/SeeReflectionEsum.h
@@ -1,0 +1,11 @@
+#ifndef _SEE_REFLECTION_ESUM_H
+#define _SEE_REFLECTION_ESUM_H
+
+#include <unistd.h>
+
+#define MAX_ERRORS 50
+
+int SeeReflectionEsum(int crateNum, uint32_t slotMask, int dacValue, float frequency, int updateDB, int finalTest=0);
+
+#endif
+

--- a/src/tests/SeeReflectionEsum.h
+++ b/src/tests/SeeReflectionEsum.h
@@ -3,8 +3,6 @@
 
 #include <unistd.h>
 
-#define MAX_ERRORS 50
-
 int SeeReflectionEsum(int crateNum, uint32_t slotMask, int dacValue, float frequency, int updateDB, int finalTest=0);
 
 #endif

--- a/src/tut/tut.c
+++ b/src/tut/tut.c
@@ -107,6 +107,7 @@ COMMAND commands[] = {
     { "mem_test", (Function *)NULL, (char *)NULL },
     { "ped_run", (Function *)NULL, (char *)NULL },
     { "see_refl", (Function *)NULL, (char *)NULL },
+    { "esum_see_refl", (Function *)NULL, (char *)NULL },
     { "trigger_scan", (Function *)NULL, (char *)NULL },
     { "get_ttot", (Function *)NULL, (char *)NULL },
     { "set_ttot", (Function *)NULL, (char *)NULL },


### PR DESCRIPTION
This updates the chinj scan to error on missing pmt signals by looking at cell 0 on each channel at the high charge injection DAC value and comparing the QHL of that cell to a user-set limit (default 1000). 

This also adds a new test called esum_see_refl to look at esum triggers in groups of 4.