### PR TITLE
Add a new test to look for missing triggers

### DIFF
--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -1234,8 +1234,8 @@ void *ControllerLink::ProcessCommand(void *arg)
 
   }else if (strncmp(input,"scan_refl",9) == 0){
     if (GetFlag(input,'h')){
-      lprintf("Usage: see_refl -c [crate num (int)] "
-          "-v [dac value (int)] -s [slot mask (hex)] "
+      lprintf("Usage: scan_refl -c [crate num (int)] "
+          "-s [slot mask (hex)] "
           "-t [trigger to enable (00-13)] -v [threshold dac] "
           "-f [frequency (float)] -p [channel mask (hex)] "
           "-d (update database)\n");
@@ -1245,8 +1245,8 @@ void *ControllerLink::ProcessCommand(void *arg)
     uint32_t slotMask = GetUInt(input,'s',0xFFFF);
     uint32_t channelMask = GetUInt(input,'p',0xFFFFFFFF);
     int triggerSelect = GetInt(input,'t',0);
-    int dacCounts = GetInt(input,'v',0);
     float frequency = GetFloat(input,'f',20);
+    int dacCounts = GetInt(input,'v',0);
     int update = GetFlag(input,'d');
     int busy = LockConnections(1,0x1<<crateNum);
     if (busy){

--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -1229,7 +1229,7 @@ void *ControllerLink::ProcessCommand(void *arg)
     SeeReflectionEsum(crateNum,slotMask,dacValue,frequency,update);
     UnlockConnections(1,0x1<<crateNum);
 
-  }else if (strncmp(input,"scan_refl",8) == 0){
+  }else if (strncmp(input,"scan_refl",9) == 0){
     if (GetFlag(input,'h')){
       lprintf("Usage: see_refl -c [crate num (int)] "
           "-v [dac value (int)] -s [slot mask (hex)] "

--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -1233,7 +1233,7 @@ void *ControllerLink::ProcessCommand(void *arg)
     if (GetFlag(input,'h')){
       lprintf("Usage: see_refl -c [crate num (int)] "
           "-v [dac value (int)] -s [slot mask (hex)] "
-          "-t [trigger to enable (0-13)] -v [threshold dac] "
+          "-t [trigger to enable (00-13)] -v [threshold dac] "
           "-f [frequency (float)] -p [channel mask (hex)] "
           "-d (update database)\n");
       goto err;

--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -21,6 +21,7 @@
 #include "PedRun.h"
 #include "SeeReflection.h"
 #include "SeeReflectionEsum.h"
+#include "ScanReflections.h"
 #include "TriggerScan.h"
 #include "TTot.h"
 #include "VMon.h"
@@ -1241,7 +1242,7 @@ void *ControllerLink::ProcessCommand(void *arg)
     uint32_t slotMask = GetUInt(input,'s',0xFFFF);
     uint32_t channelMask = GetUInt(input,'p',0xFFFFFFFF);
     int triggerSelect = GetInt(input,'t',0);
-    int dacCount = GetInt(input,'v',0);
+    int dacCounts = GetInt(input,'v',0);
     float frequency = GetFloat(input,'f',20);
     int update = GetFlag(input,'d');
     int busy = LockConnections(1,0x1<<crateNum);

--- a/src/mtc/MTCRegisters.h
+++ b/src/mtc/MTCRegisters.h
@@ -139,7 +139,7 @@
 #define MSK_CRATE23 0x00400000UL
 #define MSK_CRATE24 0x00800000UL
 #define MSK_CRATE25 0x01000000UL
-#define MSK_TUB_B   MAK_CRATE20         // everyone's second favorite board!
+#define MSK_TUB_B   MSK_CRATE20         // everyone's second favorite board!
 #define MSK_TUB     MSK_CRATE21         // everyone's favorite board!  
 #define MSK_TUBII   MSK_CRATE24         // Eric's favorite board!!
 /* Threshold Monitoring */

--- a/src/tests/ScanReflections.cpp
+++ b/src/tests/ScanReflections.cpp
@@ -29,7 +29,7 @@ int ScanReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int tr
 
     // set up pulser
     int errors = mtc->SetupPedestals(frequency, DEFAULT_PED_WIDTH, DEFAULT_GT_DELAY,0,
-        (0x1<<crateNum), MSK_TUB | MSK_TUB_B);
+        (0x1<<crateNum), (0x1<<crateNum) | MSK_TUB | MSK_TUB_B);
     if (errors){
       lprintf("Error setting up MTC for pedestals. Exiting\n");
       mtc->UnsetPedCrateMask(MASKALL);

--- a/src/tests/ScanReflections.cpp
+++ b/src/tests/ScanReflections.cpp
@@ -37,6 +37,8 @@ int ScanReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int tr
       return -1;
     }
 
+    lprintf("Setting MTC trigger thresholds!\n");
+
     mtc->UnsetGTMask(0xFFFFFFFF);
     mtc->LoadMTCADacsByCounts(counts);
     usleep(500);
@@ -63,6 +65,9 @@ int ScanReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int tr
                 return -1;
               }
             }
+
+            // wait until something is typed
+            lprintf("Slot %d, channel %d. If good, hit enter. Otherwise type in a description of the problem (or just \"fail\") and hit enter.\n",i,j);
 
             contConnection->GetInput(channel_results[j],100);
 

--- a/src/tests/ScanReflections.cpp
+++ b/src/tests/ScanReflections.cpp
@@ -9,11 +9,12 @@
 #include "XL3Model.h"
 #include "MTCModel.h"
 #include "ScanReflections.h"
+#include "XL3Cmds.h"
+#include "MTCCmds.h"
 
 int ScanReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int triggerSelect, uint16_t dacCounts, float frequency, int updateDB)
 {
-  lprintf("*** Starting See Reflection ************\n");
-  lprintf("MAKE SURE YOU HAVE REINITIALIZED WITH TRIGGERS ENABLED FIRST! (-t OPTION IN CRATE_INIT\n");
+  lprintf("*** Starting Scan Reflection ************\n");
 
   char channel_results[32][100];
 
@@ -37,16 +38,17 @@ int ScanReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int tr
       return -1;
     }
 
-    lprintf("Setting MTC trigger thresholds!\n");
-
-    mtc->UnsetGTMask(0xFFFFFFFF);
-    mtc->LoadMTCADacsByCounts(counts);
-    usleep(500);
-    mtc->SetGTMask(0x1<<(triggerSelect)-1);
-
     // loop over slots
     for (int i=0;i<16;i++){
-      if ((0x1<<i) & slotMask){
+      if ((0x1<<i) & slotMask){ 
+
+        CrateInit(crateNum,slotMask,0,0,0,0,0,0,0,0,1);
+
+        mtc->UnsetGTMask(0xFFFFFFFF);
+        mtc->LoadMTCADacsByCounts(counts);
+        usleep(500);
+        mtc->SetGTMask(0x1<<(triggerSelect)-1);
+
         // loop over channels
         for (int j=0;j<32;j++){
           if ((0x1<<j) & channelMask){
@@ -81,8 +83,10 @@ int ScanReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int tr
               xl3s[crateNum]->DeselectFECs();
               return 0;
             }
+
           } // end pattern mask
         } // end loop over channels
+        CrateInit(crateNum,slotMask,0,0,0,0,0,0,0,0,0);
 
         // update the database
         if (updateDB){

--- a/src/tests/ScanReflections.cpp
+++ b/src/tests/ScanReflections.cpp
@@ -10,12 +10,20 @@
 #include "MTCModel.h"
 #include "ScanReflections.h"
 
-int ScanReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int triggerSelect, int dacCounts, float frequency, int updateDB)
+int ScanReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int triggerSelect, uint16_t dacCounts, float frequency, int updateDB)
 {
   lprintf("*** Starting See Reflection ************\n");
   lprintf("MAKE SURE YOU HAVE REINITIALIZED WITH TRIGGERS ENABLED FIRST! (-t OPTION IN CRATE_INIT\n");
 
   char channel_results[32][100];
+
+  uint16_t counts[14];
+  for(int i = 0; i < 14; i++){
+    if(i == triggerSelect)
+      counts[i] = dacCounts;
+    else
+      counts[i] = 0;
+  } 
 
   try {
 
@@ -30,8 +38,8 @@ int ScanReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int tr
     }
 
     mtc->UnsetGTMask(0xFFFFFFFF);
-    mtc->LoadMTCADacsByCounts(dacCounts);
-    uleep(500);
+    mtc->LoadMTCADacsByCounts(counts);
+    usleep(500);
     mtc->SetGTMask(0x1<<(triggerSelect)-1);
 
     // loop over slots

--- a/src/tests/ScanReflections.h
+++ b/src/tests/ScanReflections.h
@@ -2,6 +2,8 @@
 #define _SCAN_REFLECTIONS_H
 
 #include <unistd.h>
+#include <iostream>
+#include <cmath>
 
 #define MAX_ERRORS 50
 

--- a/src/tests/ScanReflections.h
+++ b/src/tests/ScanReflections.h
@@ -1,11 +1,11 @@
-#ifndef _SEE_REFLECTION_H
-#define _SEE_REFLECTION_H
+#ifndef _SCAN_REFLECTIONS_H
+#define _SCAN_REFLECTIONS_H
 
 #include <unistd.h>
 
 #define MAX_ERRORS 50
 
-int SeeReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int dacValue, float frequency, int updateDB);
+int ScanReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int triggerSelect, uint16_t dacCounts, float frequency, int updateDB);
 
 #endif
 

--- a/src/tests/SeeReflection.cpp
+++ b/src/tests/SeeReflection.cpp
@@ -21,7 +21,7 @@ int SeeReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int dac
 
     // set up pulser
     int errors = mtc->SetupPedestals(frequency, DEFAULT_PED_WIDTH, DEFAULT_GT_DELAY,0,
-        (0x1<<crateNum),(0x1<<crateNum) | MSK_TUB);
+        (0x1<<crateNum),(0x1<<crateNum) | MSK_TUB | MSK_TUB_B);
     if (errors){
       lprintf("Error setting up MTC for pedestals. Exiting\n");
       mtc->UnsetPedCrateMask(MASKALL);

--- a/src/tests/SeeReflection.cpp
+++ b/src/tests/SeeReflection.cpp
@@ -64,6 +64,8 @@ int SeeReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int dac
 
             if (strncmp(channel_results[j],"quit",4) == 0){
               lprintf("Quitting.\n");
+              mtc->DisablePulser();
+              xl3s[crateNum]->DeselectFECs();
               return 0;
             }
 

--- a/src/tests/SeeReflection.h
+++ b/src/tests/SeeReflection.h
@@ -1,11 +1,11 @@
-#ifndef _SCAN_REFLECTIONS_H
-#define _SCAN_REFLECTIONS_H
+#ifndef _SEE_REFLECTION_H
+#define _SEE_REFLECTION_H
 
 #include <unistd.h>
 
 #define MAX_ERRORS 50
 
-int ScanReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int triggerSelect, uint16_t dacCounts, float frequency, int updateDB, int finalTest=0);
+int SeeReflection(int crateNum, uint32_t slotMask, uint32_t channelMask, int dacValue, float frequency, int updateDB, int finalTest=0);
 
 #endif
 

--- a/src/tests/SeeReflectionEsum.cpp
+++ b/src/tests/SeeReflectionEsum.cpp
@@ -20,7 +20,7 @@ int SeeReflectionEsum(int crateNum, uint32_t slotMask, int dacValue, float frequ
 
     // set up pulser
     int errors = mtc->SetupPedestals(frequency, DEFAULT_PED_WIDTH, DEFAULT_GT_DELAY,0,
-        (0x1<<crateNum),(0x1<<crateNum) | MSK_TUB);
+        (0x1<<crateNum),(0x1<<crateNum) | MSK_TUB | MSK_TUB_B);
     if (errors){
       lprintf("Error setting up MTC for pedestals. Exiting\n");
       mtc->UnsetPedCrateMask(MASKALL);

--- a/src/tut/tut.c
+++ b/src/tut/tut.c
@@ -108,6 +108,7 @@ COMMAND commands[] = {
     { "ped_run", (Function *)NULL, (char *)NULL },
     { "see_refl", (Function *)NULL, (char *)NULL },
     { "esum_see_refl", (Function *)NULL, (char *)NULL },
+    { "scan_refl", (Function *)NULL, (char *)NULL },
     { "trigger_scan", (Function *)NULL, (char *)NULL },
     { "get_ttot", (Function *)NULL, (char *)NULL },
     { "set_ttot", (Function *)NULL, (char *)NULL },


### PR DESCRIPTION
Add a new scan_refl test. The user chooses a trigger (00-13) and trigger threshold (in DAC counts) to load to the MTCA+. The trigger scan should be used to determine the trigger threshold. Similar to the see_refl, this test goes through and pedestals a channel at time to check for missing n20/n100. The idea is to set the trigger threshold to roughly half an nhit and listen to the tub clicks. This will require separately running this test for n100/n20.  

This test is a little more automated than the "see_refl" test. First, it does not require looking at the scope. Second, it is easy to run crate-wide (rather than slot-wide) because it handles enabling the triggers one slot at a time.