### PR TITLE
fecdoc fix

### DIFF
--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -1530,16 +1530,7 @@ void *ControllerLink::ProcessCommand(void *arg)
     char loadECAL[500];
     memset(loadECAL,'\0',sizeof(loadECAL));
     GetString(input,loadECAL,'l',"");
-    int busy = LockConnections(1,crateMask);
-    if (busy){
-      if (busy > 9)
-        lprintf("Trying to access a board that has not been connected\n");
-      else
-        lprintf("ThoseConnections are currently in use.\n");
-      goto err;
-    }
     CreateFECDocs(crateMask, slotMasks, loadECAL);
-    UnlockConnections(1,crateMask);
 
   }else if (strncmp(input,"find_noise",10) == 0){
     if (GetFlag(input,'h')){

--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -1095,8 +1095,10 @@ void *ControllerLink::ProcessCommand(void *arg)
       goto err;
     }
     int crateNum = GetInt(input,'c',2);
+    uint32_t slotMask = GetUInt(input,'s',0xFFFF);
     uint32_t slotMasks[MAX_XL3_CON];
-    GetMultiUInt(input,MAX_XL3_CON,'s',slotMasks,0xFFFF);
+    for (int ic=0;ic<MAX_XL3_CON;ic++)
+      slotMasks[ic] = slotMask;
     uint32_t channelMask = GetUInt(input,'p',0xFFFFFFFF);
     float gtCutoff = GetFloat(input,'g',410);
     int twiddleOn = GetFlag(input,'t');
@@ -1110,7 +1112,7 @@ void *ControllerLink::ProcessCommand(void *arg)
         lprintf("ThoseConnections are currently in use.\n");
       goto err;
     }
-    GTValidTest(crateNum,slotMasks,channelMask,gtCutoff,twiddleOn,setOnly,update);
+    GTValidTest((0x1)<<crateNum,slotMasks,channelMask,gtCutoff,twiddleOn,setOnly,update);
     UnlockConnections(1,0x1<<crateNum);
 
   }else if (strncmp(input,"mb_stability_test",17) == 0){

--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -1095,10 +1095,8 @@ void *ControllerLink::ProcessCommand(void *arg)
       goto err;
     }
     int crateNum = GetInt(input,'c',2);
-    uint32_t slotMask = GetUInt(input,'s',0xFFFF);
     uint32_t slotMasks[MAX_XL3_CON];
-    for (int ic=0;ic<MAX_XL3_CON;ic++)
-      slotMasks[ic] = slotMask;
+    GetMultiUInt(input,MAX_XL3_CON,'s',slotMasks,0xFFFF);
     uint32_t channelMask = GetUInt(input,'p',0xFFFFFFFF);
     float gtCutoff = GetFloat(input,'g',410);
     int twiddleOn = GetFlag(input,'t');

--- a/src/db/DB.cpp
+++ b/src/db/DB.cpp
@@ -800,13 +800,22 @@ int GenerateFECDocFromECAL(uint32_t crateMask, uint32_t *slotMasks, const char* 
              count_tests[testRan]=0;
           }
 
+          int time[5] = {0};
           for (int k=0;k<total_rows;k++){
             JsonNode *ecalone_row = json_find_element(ecal_rows,k);
             JsonNode *test_doc = json_find_member(ecalone_row,"value");
             JsonNode *config = json_find_member(test_doc,"config");
             char *testtype = json_get_string(json_find_member(test_doc,"type"));
-            if ((json_get_number(json_find_member(config,"crate_id")) == i) && (json_get_number(json_find_member(config,"slot")) == j)){
-              AddECALTestResults(doc,test_doc);
+            for(int ttype=0; ttype<ntests; ttype++){
+              if(strcmp(testtype, test_map[ttype])==0){
+                int timestamp = (int)json_get_number(json_find_member(test_doc,"timestamp"));
+                if(time[ttype] == 0 || timestamp > time[ttype]){
+                  time[ttype] = timestamp;
+                  if ((json_get_number(json_find_member(config,"crate_id")) == i) && (json_get_number(json_find_member(config,"slot")) == j)){
+                    AddECALTestResults(doc,test_doc);
+                  }
+                }
+              }
             }
           }
 

--- a/src/db/DB.h
+++ b/src/db/DB.h
@@ -14,7 +14,7 @@
 #define DEF_DB_VIEWDOC "_design/view_doc/_view"
 
 const static int ntests = 5;
-static const char test_map[5][20] = {"crate_cbal","zdisc","set_ttot","cmos_gtvalid","find_noise"};
+static const char test_map[ntests][20] = {"crate_cbal","zdisc","set_ttot","cmos_m_gtvalid","find_noise_2"};
 
 int GetNewID(char* newid);
 


### PR DESCRIPTION
- Handles creation of FECDocs when multiple of the same test exist in an ECAL. Checks the timestamp each tests was created and only loads the values to the FECDoc for the most recently created test. 
- Gets rid of the busy lock so FECDocs can be created at anytime, not just from underground with the crate on.