### PR TITLE
speedup find noise and make changes default

### DIFF
--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -1534,12 +1534,13 @@ void *ControllerLink::ProcessCommand(void *arg)
 
   }else if (strncmp(input,"find_noise",10) == 0){
     if (GetFlag(input,'h')){
-      lprintf("Usage: find_noise -c [crate mask (hex)] -(00-18) [slot masks (hex)] -s [all slot masks (hex)] -c (include individual channel threshold tuning) -d (update database)\n");
+      lprintf("Usage: find_noise -c [crate mask (hex)] -(00-18) [slot masks (hex)] -s [all slot masks (hex)] -f [ped frequency (int)] -c (include individual channel threshold tuning) -d (update database)\n");
       goto err;
     }
     uint32_t crateMask = GetUInt(input,'c',0x4);
     uint32_t slotMasks[MAX_XL3_CON];
     GetMultiUInt(input,MAX_XL3_CON,'s',slotMasks,0xFFFF);
+    float frequency = GetFloat(input,'f',20);
     int channel = GetFlag(input,'c');
     int updateDB = GetFlag(input,'d');
     int busy = LockConnections(1,crateMask);
@@ -1550,7 +1551,7 @@ void *ControllerLink::ProcessCommand(void *arg)
         lprintf("ThoseConnections are currently in use.\n");
       goto err;
     }
-    FindNoise(crateMask,slotMasks,20,1,channel,updateDB);
+    FindNoise(crateMask,slotMasks,frequency,1,channel,updateDB);
     UnlockConnections(1,crateMask);
 
   }else if (strncmp(input,"dac_sweep",9) == 0){

--- a/src/tests/ECAL.cpp
+++ b/src/tests/ECAL.cpp
@@ -258,7 +258,9 @@ int ECAL(uint32_t crateMask, uint32_t *slotMasks, uint32_t testMask, int quickFl
     testCounter++;
 
     if ((0x1<<testCounter) & testMask)
-      FindNoise(crateMask,slotMasks,20,1,0,1,1);
+      for (int i=0;i<MAX_XL3_CON;i++)
+        if ((0x1<<i) & crateMask)
+          FindNoise((0x1<<i),slotMasks,100,1,1,1,1);
 
     lprintf("ECAL finished!\n");
 

--- a/src/tests/FindNoise.cpp
+++ b/src/tests/FindNoise.cpp
@@ -12,7 +12,6 @@
 #include "FindNoise.h"
 
 
-
 int FindNoise(uint32_t crateMask, uint32_t *slotMasks, float frequency, int useDebug, int channel, int updateDB, int ecal)
 {
   lprintf("*** Starting Noise Run *****************\n");
@@ -441,11 +440,11 @@ int FindNoise(uint32_t crateMask, uint32_t *slotMasks, float frequency, int useD
                 // CMOS rate polling is done on bottom and top 8 slot seperately,
                 // thus the two slotIter counters and this if/else condition
                 if(j < 8){
-                   xl3s[i]->GetCmosTotalCount(slotMasks[i], total_count1);
+                   xl3s[i]->GetCmosTotalCount(slotMasks[i] & 0xFF, total_count1);
                    readout_noise[i*16*32+j*32+k] = total_count1[slotIter][k];
                 }
                 else{ 
-                   xl3s[i]->GetCmosTotalCount(slotMasks[i], total_count1);
+                   xl3s[i]->GetCmosTotalCount(slotMasks[i] & 0xFF00, total_count1);
                    readout_noise[i*16*32+j*32+k] = total_count1[slotIter2][k];
                 }
 
@@ -454,11 +453,11 @@ int FindNoise(uint32_t crateMask, uint32_t *slotMasks, float frequency, int useD
                   usleep(SLEEP_TIME);
 
                 if(j < 8){ 
-                   xl3s[i]->GetCmosTotalCount(slotMasks[i], total_count1);
+                   xl3s[i]->GetCmosTotalCount(slotMasks[i] & 0xFF, total_count1);
                    readout_noise[i*16*32+j*32+k] = total_count1[slotIter][k] - readout_noise[i*16*32+j*32+k];
                 }
                 else{ 
-                   xl3s[i]->GetCmosTotalCount(slotMasks[i], total_count1);
+                   xl3s[i]->GetCmosTotalCount(slotMasks[i] & 0xFF00, total_count1);
                    readout_noise[i*16*32+j*32+k] = total_count1[slotIter2][k] - readout_noise[i*16*32+j*32+k];
                 }
 

--- a/src/tests/FindNoise.h
+++ b/src/tests/FindNoise.h
@@ -5,7 +5,7 @@
 
 #define STARTING_THRESH -5
 #define MAX_THRESH 30
-#define SLEEP_TIME 1000000
+#define SLEEP_TIME 50000
 #define MAX_ITERATIONS 100
 
 int FindNoise(uint32_t crateMask, uint32_t *slotMasks, float frequency, int useDebug, int channel, int updateDB, int ecal=0);


### PR DESCRIPTION
changes the default sleep time and pedestal frequency for the find noise test as well as makes the updated algorithm run by default during an ECAL. 