### PR TITLE
add +1 to the discriminator thresholds

### DIFF
--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -1597,14 +1597,15 @@ void *ControllerLink::ProcessCommand(void *arg)
 
   }else if (strncmp(input,"find_noise",10) == 0){
     if (GetFlag(input,'h')){
-      lprintf("Usage: find_noise -c [crate mask (hex)] -(00-18) [slot masks (hex)] -s [all slot masks (hex)] -f [ped frequency (int)] -c (include individual channel threshold tuning) -d (update database)\n");
+      lprintf("Usage: find_noise -c [crate mask (hex)] -(00-18) [slot masks (hex)] -s [all slot masks (hex)] \n -f [ped frequency (int)] \n -i (include individual channel threshold tuning) \n -o (use with -i flag to increment channel thresholds by one) \n -d (update database)\n");
       goto err;
     }
     uint32_t crateMask = GetUInt(input,"c",0x4);
     uint32_t slotMasks[MAX_XL3_CON];
     GetMultiUInt(input,MAX_XL3_CON,'s',slotMasks,0xFFFF);
     float frequency = GetFloat(input,'f',200);
-    int channel = GetFlag(input,'c');
+    int channelTuning = GetFlag(input,'i');
+    int plusOne = GetFlag(input, 'o');
     int updateDB = GetFlag(input,'d');
     int busy = LockConnections(1,crateMask);
     if (busy){
@@ -1614,7 +1615,7 @@ void *ControllerLink::ProcessCommand(void *arg)
         lprintf("ThoseConnections are currently in use.\n");
       goto err;
     }
-    FindNoise(crateMask,slotMasks,frequency,1,channel,updateDB);
+    FindNoise(crateMask,slotMasks,frequency,1,channelTuning,plusOne,updateDB);
     UnlockConnections(1,crateMask);
 
   }else if (strncmp(input,"dac_sweep",9) == 0){

--- a/src/tests/ECAL.cpp
+++ b/src/tests/ECAL.cpp
@@ -292,7 +292,7 @@ int ECAL(uint32_t crateMask, uint32_t *slotMasks, uint32_t testMask, int quickFl
     if ((0x1<<testCounter) & testMask)
       for (int i=0;i<MAX_XL3_CON;i++)
         if ((0x1<<i) & crateMask)
-          FindNoise((0x1<<i),slotMasks,200,1,1,1,1);
+          FindNoise((0x1<<i),slotMasks,200,1,1,1,1,1);
 
     lprintf("ECAL finished!\n");
 

--- a/src/tests/FindNoise.h
+++ b/src/tests/FindNoise.h
@@ -9,7 +9,7 @@
 #define MAX_ITERATIONS 100
 #define MAX_NOISE_RATE 100
 
-int FindNoise(uint32_t crateMask, uint32_t *slotMasks, float frequency, int useDebug, int channel, int updateDB, int ecal=0);
+int FindNoise(uint32_t crateMask, uint32_t *slotMasks, float frequency, int useDebug, int channelTuning, int plusOne, int updateDB, int ecal=0);
 
 #endif
 


### PR DESCRIPTION
Add two flags to running the find noise test:
- If neither are set, the 'old' algorithm is used to calculate the discriminator thresholds
- If the first is set, the 'new' algorithm is used to calculate the discriminator thresholds (what we've been using)
- If both are set, +1 DAC counts are added to the results of the 'new' algorithm

Also, I commented out a bunch of not very useful print statements.