### PR TITLE
Channel problems, Crate CBal bug fix, Compiler warning fixes

### DIFF
--- a/src/db/DB.cpp
+++ b/src/db/DB.cpp
@@ -875,6 +875,7 @@ int GenerateFECDocFromECAL(uint32_t crateMask, uint32_t *slotMasks, const char* 
             }
             if(LoadChannelStatusToDetectorDB(doc, crate, slot, ecalID, detectorDB)){
               lprintf("Warning: Failure pushing channel status info to detector DB for crate %d slot %d. \n");
+            }
           }
           else{
               // While uploading, print any failures

--- a/src/db/DB.cpp
+++ b/src/db/DB.cpp
@@ -873,8 +873,8 @@ int GenerateFECDocFromECAL(uint32_t crateMask, uint32_t *slotMasks, const char* 
             if(LoadZDiscToDetectorDB(doc, i, j, id, detectorDB)){
               lprintf("Warning: Failure pushing zdisc info to detector DB for crate %d slot %d. \n", i, j);
             }
-            if(LoadChannelStatusToDetectorDB(doc, i, j, ecalID, detectorDB)){
-              lprintf("Warning: Failure pushing channel status info to detector DB for crate %d slot %d. \n", i, j);
+            if(LoadChannelProblemsToDetectorDB(doc, i, j, ecalID, detectorDB)){
+              lprintf("Warning: Failure pushing channel problems info to detector DB for crate %d slot %d. \n", i, j);
             }
           }
           else{

--- a/src/db/DB.cpp
+++ b/src/db/DB.cpp
@@ -873,8 +873,8 @@ int GenerateFECDocFromECAL(uint32_t crateMask, uint32_t *slotMasks, const char* 
             if(LoadZDiscToDetectorDB(doc, i, j, id, detectorDB)){
               lprintf("Warning: Failure pushing zdisc info to detector DB for crate %d slot %d. \n", i, j);
             }
-            if(LoadChannelStatusToDetectorDB(doc, crate, slot, ecalID, detectorDB)){
-              lprintf("Warning: Failure pushing channel status info to detector DB for crate %d slot %d. \n");
+            if(LoadChannelStatusToDetectorDB(doc, i, j, ecalID, detectorDB)){
+              lprintf("Warning: Failure pushing channel status info to detector DB for crate %d slot %d. \n", i, j);
             }
           }
           else{

--- a/src/db/DB.cpp
+++ b/src/db/DB.cpp
@@ -873,7 +873,7 @@ int GenerateFECDocFromECAL(uint32_t crateMask, uint32_t *slotMasks, const char* 
             if(LoadZDiscToDetectorDB(doc, i, j, id, detectorDB)){
               lprintf("Warning: Failure pushing zdisc info to detector DB for crate %d slot %d. \n", i, j);
             }
-            if(LoadChannelProblemsToDetectorDB(doc, i, j, ecalID, detectorDB)){
+            if(LoadChannelProblemsToDetectorDB(doc, i, j, id, detectorDB)){
               lprintf("Warning: Failure pushing channel problems info to detector DB for crate %d slot %d. \n", i, j);
             }
           }

--- a/src/db/DB.cpp
+++ b/src/db/DB.cpp
@@ -378,8 +378,8 @@ int AddECALTestResults(JsonNode *fec_doc, JsonNode *test_doc, unsigned int* chan
      }
      json_append_element(rmp,json_mknumber(json_get_number(json_find_member(one_chip,"rmp"))));
      json_append_element(vsi,json_mknumber(json_get_number(json_find_member(one_chip,"vsi"))));
-     json_append_element(rmpup,json_mknumber(115)); //FIXME -- Not used
-     json_append_element(vli,json_mknumber(120)); //FIXME -- Not used
+     json_append_element(rmpup,json_mknumber(115)); // Not used
+     json_append_element(vli,json_mknumber(120)); // Not used
    }
    json_append_member(tdisc,"rmp",rmp);
    json_append_member(tdisc,"rmpup",rmpup);
@@ -452,7 +452,24 @@ int AddECALTestResults(JsonNode *fec_doc, JsonNode *test_doc, unsigned int* chan
       }
     }
   }
-  // TODO -- could add FEC test, disc check here
+  else if (strcmp(type, "fec_test") == 0){
+    JsonNode *channels = json_find_member(test_doc,"cmos_test_reg");
+    for (i=0;i<32;i++){
+      if (json_get_bool(json_find_element(channels,i))){
+        chan_prob_array[i] |= (1<<fec_test_fail);
+      }
+    }
+  }
+  else if (strcmp(type, "disc_check") == 0){
+    JsonNode *channels = json_find_member(test_doc,"channels");
+    for (i=0;i<32;i++){
+      JsonNode *onechan = json_find_element(channels,i);
+      int chan_num = (int) json_get_number(json_find_member(onechan,"id"));
+      if ((int) json_get_number(json_find_member(onechan,"errors")) == 1){
+        chan_prob_array[i] |= (1<<disc_check_fail);
+      }
+    }
+  }
 
   JsonNode *new_channel = json_mkobject();
   JsonNode *new_chan_problems = json_mkarray();
@@ -856,6 +873,8 @@ int GenerateFECDocFromECAL(uint32_t crateMask, uint32_t *slotMasks, const char* 
             if(LoadZDiscToDetectorDB(doc, i, j, id, detectorDB)){
               lprintf("Warning: Failure pushing zdisc info to detector DB for crate %d slot %d. \n", i, j);
             }
+            if(LoadChannelStatusToDetectorDB(doc, crate, slot, ecalID, detectorDB)){
+              lprintf("Warning: Failure pushing channel status info to detector DB for crate %d slot %d. \n");
           }
           else{
               // While uploading, print any failures

--- a/src/db/DB.cpp
+++ b/src/db/DB.cpp
@@ -455,7 +455,7 @@ int AddECALTestResults(JsonNode *fec_doc, JsonNode *test_doc, unsigned int* chan
   else if (strcmp(type, "fec_test") == 0){
     JsonNode *channels = json_find_member(test_doc,"cmos_test_reg");
     for (i=0;i<32;i++){
-      if (json_get_bool(json_find_element(channels,i))){
+      if(!(json_get_bool(json_find_element(channels,i)))){
         chan_prob_array[i] |= (1<<fec_test_fail);
       }
     }

--- a/src/db/DB.h
+++ b/src/db/DB.h
@@ -20,7 +20,7 @@ static const char test_map[ntests][20] = {
     "crate_cbal","zdisc","set_ttot","cmos_m_gtvalid","find_noise_2"};
 
 // A couple non-critical test that are useful to keep track of errors for
-const static int nntests = 3;
+const static int nntests = 5;
 static const char test_map_ncrit[nntests][20] = 
     {"ped_run", "cgt_test", "get_ttot", "fec_test", "disc_check"};
 

--- a/src/db/DB.h
+++ b/src/db/DB.h
@@ -16,16 +16,18 @@
 
 // Critical ECAL tests, must run with each ECAL
 const static int ntests = 5;
-static const char test_map[ntests][20] = {"crate_cbal","zdisc","set_ttot","cmos_m_gtvalid","find_noise_2"};
+static const char test_map[ntests][20] = {
+    "crate_cbal","zdisc","set_ttot","cmos_m_gtvalid","find_noise_2"};
 
 // A couple non-critical test that are useful to keep track of errors for
 const static int nntests = 3;
-static const char test_map_ncrit[nntests][20] = {"ped_run", "cgt_test", "get_ttot"};
+static const char test_map_ncrit[nntests][20] = 
+    {"ped_run", "cgt_test", "get_ttot", "fec_test", "disc_check"};
 
 // Map from test to error bit
 enum Bit { cbal_fail = 0, zdisc_fail = 1, sttot_fail = 2, 
            gtvalid_fail = 3, ped_fail = 4, cgt_fail = 5, 
-           gttot_fail = 6 };
+           gttot_fail = 6 , fec_test_fail = 7, disc_check_fail = 8};
 
 int GetNewID(char* newid);
 

--- a/src/db/DetectorDB.cpp
+++ b/src/db/DetectorDB.cpp
@@ -193,7 +193,7 @@ int LoadGTValidsToDetectorDB(JsonNode* doc, int crate, int slot, const char* eca
   return 0;
 }
 
-int LoadChannelStatusToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB){
+int LoadChannelProblemsToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB){
 
   char str_dbid[512];
   char str_problems[512];

--- a/src/db/DetectorDB.cpp
+++ b/src/db/DetectorDB.cpp
@@ -193,6 +193,56 @@ int LoadGTValidsToDetectorDB(JsonNode* doc, int crate, int slot, const char* eca
   return 0;
 }
 
+int LoadChannelStatusToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGConn* detectorDB){
+
+  char str_dbid[512];
+  char str_problems[512];
+  int dbid[4];
+
+  // IDs
+  int mbid =  (int)strtoul(json_get_string(json_find_member(doc,"board_id")), (char**) NULL, 16);
+  JsonNode* id = json_find_member(doc, "id"); 
+  dbid[0] = (int)strtoul(json_get_string(json_find_member(id,"db0")), (char**) NULL, 16);
+  dbid[1] = (int)strtoul(json_get_string(json_find_member(id,"db1")), (char**) NULL, 16);
+  dbid[2] = (int)strtoul(json_get_string(json_find_member(id,"db2")), (char**) NULL, 16);
+  dbid[3] = (int)strtoul(json_get_string(json_find_member(id,"db3")), (char**) NULL, 16);
+  AppendStringIntArray(dbid, str_dbid, 4);
+
+  JsonNode* channel = json_find_member(doc, "channel");
+
+  // Get list of penn daq tests that failed for each channel
+  JsonNode* problems = json_find_memeber(channel, "problem");
+  AppendStringArray(problem, str_problem, 32);
+
+  char ecalid[64] = "";
+  sprintf(ecalid, "'%s'", ecalID);
+
+  const int buffer = 2048;
+  char query[buffer];
+  int size = snprintf(query, buffer, "INSERT INTO test_status "
+                  "(ecalid, crate, slot, mbid, dbid, problems) "
+                  "VALUES (%s, %d, %d, %d, %s, %s)"
+                   ecalid, crate, slot, mbid, str_dbid, str_problems); 
+
+  if(size >= buffer){
+    lprintf("ChannelStatus SQL query buffer overflow for crate %d, slot %d.\n", crate, slot);
+    return 1;
+  }
+
+  PGresult *qResult = PQexec(detectorDB, query);
+
+  if(CheckResultStatus(qResult, detectorDB)){
+    return 1;
+  }
+
+  PQclear(qResult);
+  lprintf("Successful pushed channel problems info to detector state database. \n");
+
+  return 0;
+  
+  
+}
+
 int LoadFECDocToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB){
 
   char str_dbid[512];
@@ -285,7 +335,7 @@ int LoadFECDocToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalI
                    str_tr100delay, str_tr20delay, str_tr20width);
 
   if(size >= buffer){
-    lprintf("FECDOC SQL query buffer overflow for crate %d, slot %d.\n", crate, slot);
+    lprintf("FecDoc SQL query buffer overflow for crate %d, slot %d.\n", crate, slot);
     return 1;
   }
 
@@ -296,7 +346,7 @@ int LoadFECDocToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalI
   }
 
   PQclear(qResult);
-  lprintf("Successful pushed fecdoc info to detector state database. \n");
+  lprintf("Successful pushed FecDoc info to detector state database. \n");
 
   return 0;
 }

--- a/src/db/DetectorDB.cpp
+++ b/src/db/DetectorDB.cpp
@@ -193,7 +193,7 @@ int LoadGTValidsToDetectorDB(JsonNode* doc, int crate, int slot, const char* eca
   return 0;
 }
 
-int LoadChannelStatusToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGConn* detectorDB){
+int LoadChannelStatusToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB){
 
   char str_dbid[512];
   char str_problems[512];
@@ -211,8 +211,8 @@ int LoadChannelStatusToDetectorDB(JsonNode* doc, int crate, int slot, const char
   JsonNode* channel = json_find_member(doc, "channel");
 
   // Get list of penn daq tests that failed for each channel
-  JsonNode* problems = json_find_memeber(channel, "problem");
-  AppendStringArray(problem, str_problem, 32);
+  JsonNode* problems = json_find_member(channel, "problem");
+  AppendStringArray(problems, str_problems, 32);
 
   char ecalid[64] = "";
   sprintf(ecalid, "'%s'", ecalID);
@@ -221,7 +221,7 @@ int LoadChannelStatusToDetectorDB(JsonNode* doc, int crate, int slot, const char
   char query[buffer];
   int size = snprintf(query, buffer, "INSERT INTO test_status "
                   "(ecalid, crate, slot, mbid, dbid, problems) "
-                  "VALUES (%s, %d, %d, %d, %s, %s)"
+                  "VALUES (%s, %d, %d, %d, %s, %s)",
                    ecalid, crate, slot, mbid, str_dbid, str_problems); 
 
   if(size >= buffer){

--- a/src/db/DetectorDB.h
+++ b/src/db/DetectorDB.h
@@ -18,7 +18,7 @@ int LoadZDiscToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID
 int LoadGTValidsToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB);
 
 // Load channel problems to the detector database
-int LoadChannelStatusToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGConn* detectorDB);
+int LoadChannelStatusToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB);
 
 // Load FEC Documents to the detector database
 int LoadFECDocToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB);

--- a/src/db/DetectorDB.h
+++ b/src/db/DetectorDB.h
@@ -10,14 +10,23 @@ void CloseDetectorDBConnection(PGconn* detectorDB);
 int CheckResultsStatus(PGresult* qResult, PGconn* detectorDB);
 
 // These are called ultimately from Create FEC Doc command
+// Load zdisc values to the detector database. These are measured values and are not
+// a part of the Fec Doc, which only stores hardware settings
 int LoadZDiscToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB);
 
+// Load measured GT valid lengths to detector database
 int LoadGTValidsToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB);
 
+// Load channel problems to the detector database
+int LoadChannelStatusToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGConn* detectorDB);
+
+// Load FEC Documents to the detector database
 int LoadFECDocToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB);
 
+// Update channel status in detector database for bad 
 int LoadBadDiscToDetectorDB(int crate, int slot, int channel, PGconn* detectorDB);
 
+// Update 
 int UpdateChannelStatus(int crate, int slot, int channel, PGconn* detectorDB);
 
 // Tool used for formatting SQL query for arrays size

--- a/src/db/DetectorDB.h
+++ b/src/db/DetectorDB.h
@@ -17,8 +17,8 @@ int LoadZDiscToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID
 // Load measured GT valid lengths to detector database
 int LoadGTValidsToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB);
 
-// Load channel problems to the detector database
-int LoadChannelStatusToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB);
+// Load channel problems to the detector database, which keeps track of which ECAL tests failed
+int LoadChannelProblemsToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB);
 
 // Load FEC Documents to the detector database
 int LoadFECDocToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB);

--- a/src/db/DetectorDB.h
+++ b/src/db/DetectorDB.h
@@ -23,10 +23,10 @@ int LoadChannelStatusToDetectorDB(JsonNode* doc, int crate, int slot, const char
 // Load FEC Documents to the detector database
 int LoadFECDocToDetectorDB(JsonNode* doc, int crate, int slot, const char* ecalID, PGconn* detectorDB);
 
-// Update channel status in detector database for bad 
+// Update channel status in detector database for bad zdisc
 int LoadBadDiscToDetectorDB(int crate, int slot, int channel, PGconn* detectorDB);
 
-// Update 
+// Insert current status into channel status before updating (FIXME)
 int UpdateChannelStatus(int crate, int slot, int channel, PGconn* detectorDB);
 
 // Tool used for formatting SQL query for arrays size
@@ -34,7 +34,7 @@ void AppendStringArray(JsonNode* array, char* buffer, int size);
 void AppendStringIntArray(int* array, char* buffer, int size);
 void AppendStringFloatArray(float* array, char* buffer, int size);
 
-// This is used in SeeRefl Test
+// This is used in SeeRefl test to update whether the triggers are working
 int UpdateTriggerStatus(int type, int crate, int slot, int channel, PGconn* detectorDB);
 
 // Used to get slot mask according to detectordb

--- a/src/mtc/MTCModel.h
+++ b/src/mtc/MTCModel.h
@@ -44,8 +44,8 @@ class MTCModel{
     MTCModel();
     ~MTCModel();
 
-    int CloseConnection(){fLink->CloseConnection();};
-    int Connect(){fLink->Connect();};
+    void CloseConnection(){fLink->CloseConnection();};
+    void Connect(){fLink->Connect();};
     int IsConnected(){return fLink->IsConnected();};
     int RegRead(uint32_t address, uint32_t *data);
     int RegWrite(uint32_t address, uint32_t data);

--- a/src/net/GenericLink.h
+++ b/src/net/GenericLink.h
@@ -35,7 +35,7 @@ class GenericLink{
 
     int IsConnected(){return fConnected;};
     int IsLocked(){return fLock;};
-    int SetLock(int lock){fLock = lock;};
+    void SetLock(int lock){fLock = lock;};
 
   protected:
     int fLock;

--- a/src/tests/CrateCBal.cpp
+++ b/src/tests/CrateCBal.cpp
@@ -256,13 +256,18 @@ int CrateCBal(int crateNum, uint32_t slotMask, uint32_t channelMask, int updateD
               if (iterations++ > max_iterations){
                 lprintf("Too many interations, exiting with some channels unbalanced.\n");
                 //lprintf("Making best guess for unbalanced channels\n");
-                for (int j=0;j<32;j++)
+                for (int j=0;j<32;j++){
                   if (wg == 0){
-                    if (chan_param[j].hi_balanced == 0)
-                      chan_param[j].high_gain_balance == bestguess_bal[j];
-                  }else              
-                    if (chan_param[j].low_balanced == 0)
-                      chan_param[j].low_gain_balance == bestguess_bal[j];
+                    if (chan_param[j].hi_balanced == 0){
+                      chan_param[j].high_gain_balance = bestguess_bal[j];
+                    }
+                  }
+                  else{
+                    if (chan_param[j].low_balanced == 0){
+                      chan_param[j].low_gain_balance = bestguess_bal[j];
+                    }
+                  }
+                }
                 break;
               }
 
@@ -390,7 +395,7 @@ int CrateCBal(int crateNum, uint32_t slotMask, uint32_t channelMask, int updateD
                     }
 
                     // keep track of best guess
-                    if (fabs(f1[j] < fabs(f2[j])))
+                    if (fabs(f1[j]) < fabs(f2[j]))
                       bestguess_bal[j] = x1_bal[j];
                     else
                       bestguess_bal[j] = x2_bal[j];

--- a/src/tests/ECAL.cpp
+++ b/src/tests/ECAL.cpp
@@ -134,9 +134,10 @@ int ECAL(uint32_t crateMask, uint32_t *slotMasks, uint32_t testMask, int quickFl
     }
     for (int i=0;i<11;i++){
       if ((0x1<<i) & testMask){
-        lprintf("%s \n",testList[i]);
+        lprintf("%s ",testList[i]);
       }
     }
+    lprintf("\n");
   }
   else if (!quickFlag){
     lprintf("None.\n");
@@ -158,7 +159,7 @@ int ECAL(uint32_t crateMask, uint32_t *slotMasks, uint32_t testMask, int quickFl
         lprintf("crate %d, slots 0-15\n",i);
       }
       else{
-        lprintf("crate %d, slots ");
+        lprintf("crate %d, slots ", i);
         for(int j=0; j<16; j++){
           if((0x1<<j) & slotMasks[i]){
             lprintf("%d ", j);

--- a/src/tests/ECAL.cpp
+++ b/src/tests/ECAL.cpp
@@ -154,7 +154,18 @@ int ECAL(uint32_t crateMask, uint32_t *slotMasks, uint32_t testMask, int quickFl
   // Print the crate and slot masks
   for (int i=0;i<MAX_XL3_CON;i++){
     if ((0x1<<i) & crateMask){
-      lprintf("crate %d: 0x%04x\n",i,slotMasks[i]);
+      if (slotMasks[i] == 0xFFFF){
+        lprintf("crate %d, slots 0-15\n",i);
+      }
+      else{
+        lprintf("crate %d, slots ");
+        for(int j=0; j<16; j++){
+          if((0x1<<j) & slotMasks[i]){
+            lprintf("%d ", j);
+          }
+        }
+        lprintf("\n");
+      }
     }
   }
 
@@ -264,7 +275,7 @@ int ECAL(uint32_t crateMask, uint32_t *slotMasks, uint32_t testMask, int quickFl
     if ((0x1<<testCounter) & testMask)
       for (int i=0;i<MAX_XL3_CON;i++)
         if ((0x1<<i) & crateMask)
-          DiscCheck(i,slotMasks[i],500000,1,0,1);
+          DiscCheck(i,slotMasks[i],100000,1,0,1);
     testCounter++;
 
     MTCInit(1);

--- a/src/tubii/TUBIIModel.h
+++ b/src/tubii/TUBIIModel.h
@@ -9,8 +9,8 @@ class TUBIIModel{
     TUBIIModel();
     ~TUBIIModel();
 
-    int CloseConnection(){fLink->CloseConnection();};
-    int Connect(){fLink->Connect();};
+    void CloseConnection(){fLink->CloseConnection();};
+    void Connect(){fLink->Connect();};
     int IsConnected(){return fLink->IsConnected();};
     int SendCommand(SBCPacket *packet, int withResponse = 1, int timeout = 5);
 

--- a/src/tut/tut.c
+++ b/src/tut/tut.c
@@ -26,7 +26,7 @@
 #include <signal.h>
 #include <sys/time.h>
 #include <time.h>
-
+#include <ctype.h>
 
 #define MAXDATASIZE 1440 // max number of bytes we can get at once 
 #define CONFIG_FILE_LOC "config/local"
@@ -233,7 +233,7 @@ int execute_line(char *line){
   char *word;
   /* Isolate the command word. */
   i = 0;
-  while (line[i] && isspace(line[i]) )
+  while (line[i] && isspace (line[i]) )
     i++;
   word = line + i;
   while (line[i] && !isspace (line[i]))
@@ -281,7 +281,7 @@ char **fileman_completion ();
 /* Tell the GNU Readline library how to complete.  We want to try to complete
    on command names if this is the first word in the line, or on filenames
    if not. */
-initialize_readline ()
+void initialize_readline ()
 {
   /* Allow conditional parsing of the ~/.inputrc file. */
   rl_readline_name = "FileMan";
@@ -319,7 +319,7 @@ char *command_generator(char *text, int state){
     len = strlen (text);
   }
   /* Return the next name which partially matches from the command list. */
-  while (name = commands[list_index].name)
+  while ((name = commands[list_index].name))
   {
     list_index++;
     if (strncmp (name, text, len) == 0)

--- a/src/xl3/XL3Model.cpp
+++ b/src/xl3/XL3Model.cpp
@@ -261,7 +261,7 @@ int XL3Model::MultiLoadsDac(int numDacs, uint32_t *dacNums, uint32_t *dacValues,
     if (j>=50) break;
     args->dacs[j].slotNum = slotNums[j];
     args->dacs[j].dacNum = dacNums[j];
-    args->dacs[j].dacValue = (dacValues[j] < 256 && dacValues[j] >= 0) ? dacValues[j] : 255;
+    args->dacs[j].dacValue = (dacValues[j] < 256) ? dacValues[j] : 255;
   }
   SwapLongBlock(args,numDacs*3+1);
   SendCommand(&packet);


### PR DESCRIPTION
- Introduce new "channel problems" table, which keeps tracks of tests that failed for each channel
- Fix all warnings when compiling penn daq. Led to potential bug fix in crate cbal (other changes should be harmless). 