### PR TITLE
Add measure only functionality to GTValid test

### DIFF
--- a/src/cont/ControllerLink.cpp
+++ b/src/cont/ControllerLink.cpp
@@ -1151,6 +1151,30 @@ void *ControllerLink::ProcessCommand(void *arg)
     GTValidTest((0x1)<<crateNum,slotMasks,channelMask,gtCutoff,twiddleOn,setOnly,update,detectorupdate);
     UnlockConnections(1,0x1<<crateNum);
 
+  }else if (strncmp(input,"measure_gtvalids",16) == 0){
+    if (GetFlag(input,'h')){
+      lprintf("Usage: gtvalid_test -c [crate num (int)] "
+          "-s [slot (int)] -e [isetm1 (int)] -f [isetm2 (int)] "
+          "-m [max_gtvalid (float)] -i [max_isetm (int)] \n");
+      goto err;
+    }
+    int crateNum = GetInt(input,'c',2);
+    int slotNum = GetInt(input, 's',2);
+    int isetm1 = GetInt(input, 'e', 170);
+    int isetm2 = GetInt(input, 'f', 170);
+    float max_gtvalid = GetFloat(input, 'm', 420.0); 
+    int max_isetm = GetInt(input, 'i', 80);
+    int busy = LockConnections(1,0x1<<crateNum);
+    if (busy){
+      if (busy > 9)
+        lprintf("Trying to access a board that has not been connected\n");
+      else
+        lprintf("ThoseConnections are currently in use.\n");
+      goto err;
+    }
+    MeasureGTValidOnly(crateNum, slotNum, isetm1, isetm2, max_gtvalid, max_isetm);
+    UnlockConnections(1,0x1<<crateNum);
+
   }else if (strncmp(input,"mb_stability_test",17) == 0){
     if (GetFlag(input,'h')){
       lprintf("Usage: mb_stability_test -c [crate num (int)] "

--- a/src/tests/GTValidTest.cpp
+++ b/src/tests/GTValidTest.cpp
@@ -569,6 +569,24 @@ int GTValidTest(uint32_t crateMask, uint32_t *slotMasks, uint32_t channelMask, f
   return 0;
 }
 
+void MeasureGTValidOnly(int crateNum, int slotNum, int isetm1, int isetm2, float max_gtvalid, int max_isetm){
+
+  uint32_t result;
+  int error;
+  float gtvalid_final[2][32] = {{0}};
+  for (int wt=0;wt<2;wt++){
+    lprintf("\nMeasuring GTVALID for crate %d, slot %d, TAC %d\n",crateNum,slotNum,wt);
+    // loop over channel to measure inital GTVALID and find channel with max
+    for (int j=0;j<32;j++){
+        error += xl3s[crateNum]->LoadsDac(d_isetm[0],isetm1,slotNum);
+        error += xl3s[crateNum]->LoadsDac(d_isetm[1],isetm2,slotNum);
+        xl3s[crateNum]->RW(PED_ENABLE_R + FEC_SEL*slotNum + WRITE_REG,1<<j,&result);
+        gtvalid_final[wt][j] = MeasureGTValid(crateNum,slotNum,wt,max_gtvalid,max_isetm);
+        lprintf("Channel %d TAC %d GTValid %f\n", j, wt, gtvalid_final[wt][j]);
+    } // end loop over channels
+  } // end loop over tacs
+} 
+
 // returns 1 if gtvalid is longer than time, 0 otherwise.
 // if gtvalid is longer should get hits generated from all the pedestals
 void IsGTValidLonger(uint32_t crateMask, uint32_t *slotMasks, float time, uint16_t* islonger)

--- a/src/tests/GTValidTest.h
+++ b/src/tests/GTValidTest.h
@@ -21,6 +21,7 @@
 void IsGTValidLonger(uint32_t crateMask, uint32_t *slotMasks, float time, uint16_t *islonger);
 float MeasureGTValid(int crateNum, int slotNum, int tac, float max_gtvalid, uint32_t max_isetm);
 int GTValidTest(uint32_t crateMask, uint32_t *slotMasks, uint32_t channelMask, float gtCutoff, int twiddleOn, int setOnly, int updateDB, int updateDetectorDB, int finalTest=0, int ecal=0);
+void MeasureGTValidOnly(int crateNum, int slotNum, int isetm1, int isetm2, float max_gtvalid, int max_isetm); 
 
 #endif
 

--- a/src/xl3/XL3Cmds.cpp
+++ b/src/xl3/XL3Cmds.cpp
@@ -358,7 +358,6 @@ int CrateInit(int crateNum,uint32_t slotMask, int xilinxLoad,
         }
       }
 
-
       ///////////////////////////////
       // SEND THE DATABASE TO XL3s //
       ///////////////////////////////
@@ -367,7 +366,6 @@ int CrateInit(int crateNum,uint32_t slotMask, int xilinxLoad,
 
       SwapLongBlock(packet.payload,1);	
       SwapFECDB(mb_consts);
-        //mb_consts->vThr[17] = 255; 
 
       if (enableTriggers){
         lprintf("ENABLING TRIGGERS!\n");
@@ -383,9 +381,7 @@ int CrateInit(int crateNum,uint32_t slotMask, int xilinxLoad,
       }
       xl3s[crateNum]->SendCommand(&packet,0);
 
-      //  json_delete(hw_docs[i]);
     }
-
 
     // GET CTC DELAY FROM CTC_DOC IN DB
     pouch_request *ctc_response = pr_init();


### PR DESCRIPTION
In order to check gtvalid lengths when manually setting the ISETM dacs